### PR TITLE
voc2coco and divide dataset

### DIFF
--- a/tools/misc/README.md
+++ b/tools/misc/README.md
@@ -1,0 +1,42 @@
+## Pascal voc data format to coco data format
+Note that this script does not support the integration of instance segmentation annotations.
+```
+python tools/misc/coco_split.py --xml_dir ${Directory path to xml files} \
+                                --json_file ${Output COCO format json file} \
+```
+For example:
+```
+python tools/misc/coco_split.py --xml_dir ./data/annotations \
+                                --json_file ./data \
+```
+## Divide dataset into training set, validation set and test set
+
+Usually, custom dataset is a large folder with full of images. We need to divide the dataset into training set, validation set and test set by ourselves. If the amount of data is small, we can not divide the validation set. Here’s how the split script works:
+
+```
+python tools/misc/coco_train_split.py --json ${COCO label json path} \
+                                      --out-dir ${divide label json saved path} \
+                                      --ratios ${ratio of division} \
+                                      [--shuffle] \
+                                      [--seed ${random seed for division}]
+```
+
+
+
+These include:
+
+- `--ratios`: ratio of division. If only 2 are set, the split is `trainval + test`, and if 3 are set, the split is `train + val + test`. Two formats are supported - integer and decimal:
+  - Integer: divide the dataset in proportion after normalization. Example: `--ratio 2 1 1` (the code will convert to `0.5 0.25 0.25`) or `--ratio 3 1`（the code will convert to `0.75 0.25`）
+  - Decimal: divide the dataset in proportion. **If the sum does not add up to 1, the script performs an automatic normalization correction.** Example: `--ratio 0.8 0.1 0.1` or `--ratio 0.8 0.2`
+- `--shuffle`: whether to shuffle the dataset before splitting.
+- `--seed`: the random seed of dataset division. If not set, this will be generated automatically.
+
+For example:
+
+```
+python tools/misc/coco_split.py --json ./data/cat/annotations/annotations_all.json \
+                                --out-dir ./data/cat/annotations \
+                                --ratios 0.8 0.2 \
+                                --shuffle \
+                                --seed 10
+```

--- a/tools/misc/coco_train_split.py
+++ b/tools/misc/coco_train_split.py
@@ -1,0 +1,122 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import argparse
+import json
+import random
+from pathlib import Path
+
+import numpy as np
+from pycocotools.coco import COCO
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--json', type=str, required=True, help='COCO json label path')
+    parser.add_argument(
+        '--out-dir', type=str, required=True, help='output path')
+    parser.add_argument(
+        '--ratios',
+        nargs='+',
+        type=float,
+        help='ratio for sub dataset, if set 2 number then will generate '
+        'trainval + test (eg. "0.8 0.1 0.1" or "2 1 1"), if set 3 number '
+        'then will generate train + val + test (eg. "0.85 0.15" or "2 1")')
+    parser.add_argument(
+        '--shuffle',
+        action='store_true',
+        help='Whether to display in disorder')
+    parser.add_argument('--seed', default=-1, type=int, help='seed')
+    args = parser.parse_args()
+    return args
+
+
+def split_coco_dataset(coco_json_path: str, save_dir: str, ratios: list,
+                       shuffle: bool, seed: int):
+    if not Path(coco_json_path).exists():
+        raise FileNotFoundError(f'Can not not found {coco_json_path}')
+
+    if not Path(save_dir).exists():
+        Path(save_dir).mkdir(parents=True)
+
+    # ratio normalize
+    ratios = np.array(ratios) / np.array(ratios).sum()
+
+    if len(ratios) == 2:
+        ratio_train, ratio_test = ratios
+        ratio_val = 0
+        train_type = 'trainval'
+    elif len(ratios) == 3:
+        ratio_train, ratio_val, ratio_test = ratios
+        train_type = 'train'
+    else:
+        raise ValueError('ratios must set 2 or 3 group!')
+
+    # Read coco info
+    coco = COCO(coco_json_path)
+    coco_image_ids = coco.getImgIds()
+
+    # gen image number of each dataset
+    val_image_num = int(len(coco_image_ids) * ratio_val)
+    test_image_num = int(len(coco_image_ids) * ratio_test)
+    train_image_num = len(coco_image_ids) - val_image_num - test_image_num
+    print('Split info: ====== \n'
+          f'Train ratio = {ratio_train}, number = {train_image_num}\n'
+          f'Val ratio = {ratio_val}, number = {val_image_num}\n'
+          f'Test ratio = {ratio_test}, number = {test_image_num}')
+
+    seed = int(seed)
+    if seed != -1:
+        print(f'Set the global seed: {seed}')
+        np.random.seed(seed)
+
+    if shuffle:
+        print('shuffle dataset.')
+        random.shuffle(coco_image_ids)
+
+    # split each dataset
+    train_image_ids = coco_image_ids[:train_image_num]
+    if val_image_num != 0:
+        val_image_ids = coco_image_ids[train_image_num:train_image_num +
+                                       val_image_num]
+    else:
+        val_image_ids = None
+    test_image_ids = coco_image_ids[train_image_num + val_image_num:]
+
+    # Save new json
+    categories = coco.loadCats(coco.getCatIds())
+    for img_id_list in [train_image_ids, val_image_ids, test_image_ids]:
+        if img_id_list is None:
+            continue
+
+        # Gen new json
+        img_dict = {
+            'images': coco.loadImgs(ids=img_id_list),
+            'categories': categories,
+            'annotations': coco.loadAnns(coco.getAnnIds(imgIds=img_id_list))
+        }
+
+        # save json
+        if img_id_list == train_image_ids:
+            json_file_path = Path(save_dir, f'{train_type}.json')
+        elif img_id_list == val_image_ids:
+            json_file_path = Path(save_dir, 'val.json')
+        elif img_id_list == test_image_ids:
+            json_file_path = Path(save_dir, 'test.json')
+        else:
+            raise ValueError('img_id_list ERROR!')
+
+        print(f'Saving json to {json_file_path}')
+        with open(json_file_path, 'w') as f_json:
+            json.dump(img_dict, f_json, ensure_ascii=False, indent=2)
+
+    print('All done!')
+
+
+def main():
+    args = parse_args()
+    split_coco_dataset(args.json, args.out_dir, args.ratios, args.shuffle,
+                       args.seed)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/misc/voc2coco.py
+++ b/tools/misc/voc2coco.py
@@ -1,0 +1,138 @@
+import sys
+import os
+import json
+import xml.etree.ElementTree as ET
+import glob
+
+START_BOUNDING_BOX_ID = 1
+START_IMAGE_ID = 1
+PRE_DEFINE_CATEGORIES = None
+
+
+
+def get(root, name):
+    vars = root.findall(name)
+    return vars
+
+
+def get_and_check(root, name, length):
+    vars = root.findall(name)
+    if len(vars) == 0:
+        raise ValueError("Can not find %s in %s." % (name, root.tag))
+    if length > 0 and len(vars) != length:
+        raise ValueError(
+            "The size of %s is supposed to be %d, but is %d."
+            % (name, length, len(vars))
+        )
+    if length == 1:
+        vars = vars[0]
+    return vars
+
+
+def get_categories(xml_files):
+    """Generate category name to id mapping from a list of xml files.
+    
+    Arguments:
+        xml_files {list} -- A list of xml file paths.
+    
+    Returns:
+        dict -- category name to id mapping.
+    """
+    classes_names = []
+    for xml_file in xml_files:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        for member in root.findall("object"):
+            classes_names.append(member[0].text)
+    classes_names = list(set(classes_names))
+    classes_names.sort()
+    for i, name in enumerate(classes_names):
+        print('ID %d: %s'%(i,name))
+    return {name: i for i, name in enumerate(classes_names)}
+
+
+def convert(xml_files, json_file):
+    json_dict = {"images": [], "type": "instances", "annotations": [], "categories": []}
+    if PRE_DEFINE_CATEGORIES is not None:
+        categories = PRE_DEFINE_CATEGORIES
+    else:
+        categories = get_categories(xml_files)
+    bnd_id = START_BOUNDING_BOX_ID
+    image_id = START_IMAGE_ID
+    for xml_file in xml_files:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        path = get(root, "path")
+        if len(path) == 1:
+            filename = os.path.basename(path[0].text)
+        elif len(path) == 0:
+            filename = get_and_check(root, "filename", 1).text
+        else:
+            raise ValueError("%d paths found in %s" % (len(path), xml_file))
+
+        
+        size = get_and_check(root, "size", 1)
+        width = int(get_and_check(size, "width", 1).text)
+        height = int(get_and_check(size, "height", 1).text)
+        image = {
+            "file_name": filename,
+            "height": height,
+            "width": width,
+            "id": image_id,
+        }
+        json_dict["images"].append(image)
+        image_id = image_id + 1
+
+        for obj in get(root, "object"):
+            category = get_and_check(obj, "name", 1).text
+            if category not in categories:
+                new_id = len(categories)
+                categories[category] = new_id
+            category_id = categories[category]
+            bndbox = get_and_check(obj, "bndbox", 1)
+            xmin = int(get_and_check(bndbox, "xmin", 1).text) - 1
+            ymin = int(get_and_check(bndbox, "ymin", 1).text) - 1
+            xmax = int(get_and_check(bndbox, "xmax", 1).text)
+            ymax = int(get_and_check(bndbox, "ymax", 1).text)
+            assert xmax > xmin
+            assert ymax > ymin
+            o_width = abs(xmax - xmin)
+            o_height = abs(ymax - ymin)
+            ann = {
+                "area": o_width * o_height,
+                "iscrowd": 0,
+                "image_id": image_id,
+                "bbox": [xmin, ymin, o_width, o_height],
+                "category_id": category_id,
+                "id": bnd_id,
+                "ignore": 0,
+                "segmentation": [],
+            }
+            json_dict["annotations"].append(ann)
+            bnd_id = bnd_id + 1
+
+    for cate, cid in categories.items():
+        cat = {"supercategory": "none", "id": cid, "name": cate}
+        json_dict["categories"].append(cat)
+
+    os.makedirs(os.path.dirname(json_file), exist_ok=True)
+    json_fp = open(json_file, "w")
+    json_str = json.dumps(json_dict)
+    json_fp.write(json_str)
+    json_fp.close()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Convert Pascal VOC annotation to COCO format."
+    )
+    parser.add_argument("--xml_dir", required=True, type=str, help="Directory path to xml files.")
+    parser.add_argument("--json_file", required=True, type=str, help="Output COCO format json file.")
+    args = parser.parse_args()
+    xml_files = glob.glob(os.path.join(args.xml_dir, "*.xml"))
+
+    print("Number of xml files: {}".format(len(xml_files)))
+    convert(xml_files, args.json_file)
+    print("Success: {}".format(args.json_file))


### PR DESCRIPTION
Support Pascal voc data format to coco data format. Divide dataset into training set, validation set and test set.

## Modification
The voc2coco.py script is provided for Pascal voc data format to coco data format. 
The coco_train_split.py script is provided for dataset splitting.
The README.md file is provided to explain the use of the script.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
